### PR TITLE
Fix CLI exclusion regex handling

### DIFF
--- a/bin/dirs-to-txt-file
+++ b/bin/dirs-to-txt-file
@@ -12,13 +12,9 @@ If you want to exclude secret .dotfolders and node_modules/, use the --excludese
   .describe('excludesecret', 'exclude secret .dotfolders and node_modules/')
   .coerce('exclude', arg => {
     if(Array.isArray(arg)) {
-      arg.map(v => {
-        return new RegExp(v)
-      })
-      return arg
-    } else {
-      return RegExp(arg)
+      return arg.map(v => new RegExp(v))
     }
+    return new RegExp(arg)
   })
   .argv
 


### PR DESCRIPTION
## Summary
- fix `exclude` parameter coercion in CLI

## Testing
- `npm test` *(fails: Cannot find module 'tape')*

------
https://chatgpt.com/codex/tasks/task_e_684ab8da2a688327b1008e608685889e