### PR TITLE
Add error handling to write stream

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -41,5 +41,13 @@ test('write-array-to-txt-file', t => {
       })
     })
   })
-  
+
+  t.test('it reports an error if the path does not exist', t => {
+    const badFilePath = __dirname + '/does/not/exist/test.txt'
+    writeArrayToTxtFile(['x'], badFilePath, err => {
+      t.ok(err, 'expected error is passed to callback')
+      t.end()
+    })
+  })
+
 })

--- a/write-array-to-txt-file.js
+++ b/write-array-to-txt-file.js
@@ -6,6 +6,8 @@ module.exports = function writeArrayToTxtFile(array, txtFilePath, cb) {
 
   let ws = fs.createWriteStream(txtFilePath)
 
+  ws.on('error', err => cb(err))
+
   ws.on('finish', () => {
     cb(null)
   })


### PR DESCRIPTION
## Summary
- handle `error` events in `write-array-to-txt-file`
- test that callback receives write errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c1f50e44c8327888a20e0e24f8c79